### PR TITLE
Feature/add local browser execution functionality

### DIFF
--- a/source/TestStack.Seleno.BrowserStack.Core/Configuration/BrowserConfiguration.cs
+++ b/source/TestStack.Seleno.BrowserStack.Core/Configuration/BrowserConfiguration.cs
@@ -13,6 +13,8 @@ namespace TestStack.Seleno.BrowserStack.Core.Configuration
 
         public string Device { get; set; }
 
+        public bool IsLocalWebDriver { get; set; }
+
         [JsonProperty("browser_version")]
         public string Version { get; set; }
 
@@ -42,12 +44,14 @@ namespace TestStack.Seleno.BrowserStack.Core.Configuration
             OsName = osName;
             OsVersion = osVersion;
             Resolution = resolution;
+            IsLocalWebDriver = false;
         }
 
         public BrowserConfiguration(string name, string device)
         {
             Name = name;
             Device = device;
+            IsLocalWebDriver = false;
         }
 
         public override string ToString()

--- a/source/TestStack.Seleno.BrowserStack.Core/Configuration/BrowserHost.cs
+++ b/source/TestStack.Seleno.BrowserStack.Core/Configuration/BrowserHost.cs
@@ -24,7 +24,7 @@ namespace TestStack.Seleno.BrowserStack.Core.Configuration
 
         public virtual void StartHost(Func<RemoteWebDriver> remoteWebDriverFactory, IWebServer webServer)
         {
-            _selenoHost.Run(config => config.WithRemoteWebDriver(remoteWebDriverFactory).WithWebServer(webServer));
+            _selenoHost.Run(config => config.WithRemoteWebDriver(remoteWebDriverFactory).WithWebServer(webServer));          
         }
 
         public TPage NavigateToInitialPage<TPage>(string url = "") where TPage : Page, new()
@@ -39,6 +39,7 @@ namespace TestStack.Seleno.BrowserStack.Core.Configuration
             get
             {
                 var sessionId = string.Empty;
+
                 var application = _selenoHost.Application;
                 if (application != null)
                 {

--- a/source/TestStack.Seleno.BrowserStack.Core/Configuration/BrowserHostFactory.cs
+++ b/source/TestStack.Seleno.BrowserStack.Core/Configuration/BrowserHostFactory.cs
@@ -4,6 +4,7 @@ using OpenQA.Selenium.Remote;
 using TestStack.Seleno.Configuration;
 using TestStack.Seleno.Configuration.Contracts;
 using TestStack.Seleno.Configuration.WebServers;
+using TestStack.Seleno.BrowserStack.Core.Enums;
 
 namespace TestStack.Seleno.BrowserStack.Core.Configuration
 {
@@ -18,8 +19,7 @@ namespace TestStack.Seleno.BrowserStack.Core.Configuration
             _configurationProvider = configurationProvider;
             CommandTimeOut = TimeSpan.FromMinutes(5);
         }
-
-
+        
         public IBrowserHost CreateWithCapabilities(ICapabilities capabilities, BrowserConfiguration browserConfiguration = null)
         {
             var instance = CreateBrowserHost(browserConfiguration);
@@ -33,6 +33,40 @@ namespace TestStack.Seleno.BrowserStack.Core.Configuration
         public virtual IBrowserHost CreateBrowserHost(BrowserConfiguration browserConfiguration)
         {
             return new BrowserHost(new SelenoHost(), browserConfiguration);
+        }
+
+        public virtual IBrowserHost CreateLocalWebDriver(BrowserEnum browser, BrowserConfiguration browserConfiguration = null)
+        {
+            var instance = CreateBrowserHost(browserConfiguration);
+
+            IWebDriver webDriverFunc;
+
+            switch (browser)
+            {                
+                case BrowserEnum.Firefox:
+                    webDriverFunc = BrowserFactory.FireFox();
+                    break;
+                case BrowserEnum.InternetExplorer:
+                    webDriverFunc = BrowserFactory.InternetExplorer();
+                    break;
+                case BrowserEnum.PhantomJs:
+                    webDriverFunc = BrowserFactory.PhantomJS();
+                    break;
+                case BrowserEnum.Safari:
+                    webDriverFunc = BrowserFactory.Safari();
+                    break;
+                case BrowserEnum.Chrome:
+                default:
+                    webDriverFunc = BrowserFactory.Chrome();
+                    break;                
+            }
+
+            instance.Configuration.IsLocalWebDriver = true;
+
+            instance.Run(() => (RemoteWebDriver)webDriverFunc,
+                         CreateWebServer(_configurationProvider.RemoteUrl));
+
+            return instance;
         }
 
         public virtual Func<RemoteWebDriver> CreateRemoteDriverWithCapabilities(ICapabilities capabilities)

--- a/source/TestStack.Seleno.BrowserStack.Core/Configuration/ConfigurationProvider.cs
+++ b/source/TestStack.Seleno.BrowserStack.Core/Configuration/ConfigurationProvider.cs
@@ -39,5 +39,10 @@ namespace TestStack.Seleno.BrowserStack.Core.Configuration
         {
             get { return ConfigurationManager.AppSettings[Constants.BrowserStackApiUrl]; }
         }
+
+        public string UseLocalBrowser
+        {
+            get {  return ConfigurationManager.AppSettings[Constants.UseLocalBrowser]; }
+        }
     }
 }

--- a/source/TestStack.Seleno.BrowserStack.Core/Configuration/Constants.cs
+++ b/source/TestStack.Seleno.BrowserStack.Core/Configuration/Constants.cs
@@ -5,5 +5,6 @@ namespace TestStack.Seleno.BrowserStack.Core.Configuration
         public const string BrowserStackSeleniumHubUrl = "browserStackRemoteDriverUrl";
         public const string BuildNumber = "buildNumber";
         public const string BrowserStackApiUrl = "browserStackApiUrl";
+        public const string UseLocalBrowser = "useLocalBrowser";
     }
 }

--- a/source/TestStack.Seleno.BrowserStack.Core/Configuration/IBrowserHostFactory.cs
+++ b/source/TestStack.Seleno.BrowserStack.Core/Configuration/IBrowserHostFactory.cs
@@ -1,9 +1,11 @@
 ﻿using OpenQA.Selenium;
+using TestStack.Seleno.BrowserStack.Core.Enums;
 
 namespace TestStack.Seleno.BrowserStack.Core.Configuration
 {
     public interface IBrowserHostFactory
     {
         IBrowserHost CreateWithCapabilities(ICapabilities capabilities, BrowserConfiguration browserConfiguration = null);
+        IBrowserHost CreateLocalWebDriver(BrowserEnum browser, BrowserConfiguration browserConfiguration = null);
     }
 }

--- a/source/TestStack.Seleno.BrowserStack.Core/Configuration/IConfigurationProvider.cs
+++ b/source/TestStack.Seleno.BrowserStack.Core/Configuration/IConfigurationProvider.cs
@@ -8,5 +8,6 @@ namespace TestStack.Seleno.BrowserStack.Core.Configuration
         string RemoteUrl { get; }
         string BuildNumber { get; }
         string BrowserStackApiUrl { get; }
+        string UseLocalBrowser { get; }
     }
 }

--- a/source/TestStack.Seleno.BrowserStack.Core/Configuration/RemoteBrowserConfigurator.cs
+++ b/source/TestStack.Seleno.BrowserStack.Core/Configuration/RemoteBrowserConfigurator.cs
@@ -13,6 +13,9 @@ namespace TestStack.Seleno.BrowserStack.Core.Configuration
         private readonly ICapabilitiesBuilder _capabilitiesBuilder;
         private readonly IConfigurationProvider _configurationProvider;
 
+        private const string InvalidBrowserConfigurationErrorMessage =
+            "useLocalBrowser - local browser configuration must be one of the following Chrome, Firefox, InternetExplorer, PhantomJs, Safari";
+
         public RemoteBrowserConfigurator(IBrowserHostFactory browserHostFactory, IBrowserConfigurationParser parser,
             ICapabilitiesBuilder capabilitiesBuilder, IConfigurationProvider configurationProvider)
         {
@@ -41,13 +44,13 @@ namespace TestStack.Seleno.BrowserStack.Core.Configuration
             {
                 BrowserEnum result;
 
-                try
+                if (Enum.IsDefined(typeof(BrowserEnum), _configurationProvider.UseLocalBrowser))
                 {
-                    Enum.TryParse(_configurationProvider.UseLocalBrowser.Replace(" ", string.Empty), out result);
+                    Enum.TryParse(_configurationProvider.UseLocalBrowser.Replace(" ", string.Empty), out result);                    
                 }
-                catch (InvalidBrowserConfigurationException exception)
+                else
                 {
-                    throw exception;
+                    throw new InvalidBrowserConfigurationException(InvalidBrowserConfigurationErrorMessage);
                 }
 
                 return _browserHostFactory.CreateLocalWebDriver(result, browserConfiguration);

--- a/source/TestStack.Seleno.BrowserStack.Core/Configuration/TestSpecification.cs
+++ b/source/TestStack.Seleno.BrowserStack.Core/Configuration/TestSpecification.cs
@@ -11,7 +11,5 @@ namespace TestStack.Seleno.BrowserStack.Core.Configuration
             ScenarioTitle = scenarioTitle;
             FeatureTitle = featureTitle;
         }
-
-
     }
 }

--- a/source/TestStack.Seleno.BrowserStack.Core/Enums/BrowserEnum.cs
+++ b/source/TestStack.Seleno.BrowserStack.Core/Enums/BrowserEnum.cs
@@ -1,0 +1,11 @@
+﻿namespace TestStack.Seleno.BrowserStack.Core.Enums
+{
+    public enum BrowserEnum
+    {
+        PhantomJs,
+        Chrome,
+        Firefox,
+        Safari,
+        InternetExplorer
+    }
+}

--- a/source/TestStack.Seleno.BrowserStack.Core/TestResultNotifier.cs
+++ b/source/TestStack.Seleno.BrowserStack.Core/TestResultNotifier.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Castle.Core.Internal;
 using TechTalk.SpecFlow;
 using TechTalk.SpecFlow.Tracing;
 using TestStack.Seleno.BrowserStack.Core.Configuration;
@@ -12,22 +13,26 @@ namespace TestStack.Seleno.BrowserStack.Core
         private readonly IBrowserHost _browser;
         private readonly IBrowserStackService _browserStackService;
         private readonly ITraceListener _traceListener;
+        private readonly IConfigurationProvider _configurationProvider;
 
         public TestResultNotifier(IBrowserHost browser, IBrowserStackService browserStackService,
-            ITraceListener traceListener)
+            ITraceListener traceListener, IConfigurationProvider configurationProvider)
         {
             _browser = browser;
             _browserStackService = browserStackService;
             _traceListener = traceListener;
+            _configurationProvider = configurationProvider;
         }
 
         [AfterScenario]
         public void SendFailingNotificationTestResult()
         {
+            if (!_configurationProvider.UseLocalBrowser.IsNullOrEmpty()) return;
+            
             var sessionId = _browser.SessionId;
+
             if (string.IsNullOrWhiteSpace(sessionId)) return;
-
-
+            
             if (TestException != null)
             {
                 _browserStackService.UpdateTestStatus(sessionId, SessionStatus.Error, TestException.Message);

--- a/source/TestStack.Seleno.BrowserStack.Core/TestStack.Seleno.BrowserStack.Core.csproj
+++ b/source/TestStack.Seleno.BrowserStack.Core/TestStack.Seleno.BrowserStack.Core.csproj
@@ -46,7 +46,11 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Net.Http.Formatting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="System.Net.Http.Formatting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.4.0.30506.0\lib\net40\System.Net.Http.Formatting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath>
       <Private>True</Private>
@@ -115,6 +119,7 @@
     <Compile Include="Configuration\RemoteBrowserConfigurator.cs" />
     <Compile Include="Configuration\TestSpecification.cs" />
     <Compile Include="Disposable.cs" />
+    <Compile Include="Enums\BrowserEnum.cs" />
     <Compile Include="Exceptions\InvalidBrowserConfigurationException.cs" />
     <Compile Include="Exceptions\UnsupportedBrowserException.cs" />
     <Compile Include="Extensions\BoDiExtensions.cs" />
@@ -143,7 +148,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/source/TestStack.Seleno.BrowserStack.Core/packages.config
+++ b/source/TestStack.Seleno.BrowserStack.Core/packages.config
@@ -3,7 +3,9 @@
   <package id="Castle.Core" version="3.3.3" targetFramework="net451" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net451" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net451" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="4.0.30506.0" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net451" />
+  <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net451" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net451" />
   <package id="Selenium.Support" version="2.53.0" targetFramework="net451" />

--- a/source/TestStack.Seleno.BrowserStack.SpecFlowPlugin/SeleniumNUnitTestGeneratorProvider.cs
+++ b/source/TestStack.Seleno.BrowserStack.SpecFlowPlugin/SeleniumNUnitTestGeneratorProvider.cs
@@ -144,7 +144,8 @@ namespace TestStack.Seleno.BrowserStack.SpecFlowPlugin
             _remoteBrowserConfigurator = new RemoteBrowserConfigurator(new BrowserHostFactory(configurationProvider),
                 new BrowserConfigurationParser(new BrowserStackService(configurationProvider,
                     new HttpClientFactory(configurationProvider))),
-                new CapabilitiesBuilder(configurationProvider));"));
+                new CapabilitiesBuilder(configurationProvider), 
+                configurationProvider);"));
         }
 
         #region private methods

--- a/source/TestStack.Seleno.Browserstack.UnitTests/Core/Configuration/RemoteBrowserConfiguratorSpecs.cs
+++ b/source/TestStack.Seleno.Browserstack.UnitTests/Core/Configuration/RemoteBrowserConfiguratorSpecs.cs
@@ -3,8 +3,10 @@ using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
 using OpenQA.Selenium;
+using OpenQA.Selenium.Chrome;
 using TestStack.Seleno.BrowserStack.Core.Capabilities;
 using TestStack.Seleno.BrowserStack.Core.Configuration;
+using TestStack.Seleno.BrowserStack.Core.Enums;
 using TestStack.Seleno.BrowserStack.Core.Exceptions;
 
 namespace TestStack.Seleno.Browserstack.UnitTests.Core.Configuration
@@ -112,6 +114,38 @@ namespace TestStack.Seleno.Browserstack.UnitTests.Core.Configuration
             _browserHostFactory
                 .DidNotReceive()
                 .CreateWithCapabilities(capabilities);
+        }
+        
+        [TestCase("Chrome", BrowserEnum.Chrome)]
+        [TestCase("Firefox", BrowserEnum.Firefox)]
+        [TestCase("InternetExplorer", BrowserEnum.InternetExplorer)]
+        [TestCase("PhantomJs", BrowserEnum.PhantomJs)]
+        [TestCase("Safari", BrowserEnum.Safari)]
+        public void CreateAndConfigure_ShouldCallCreateLocalBrowser(string browser, BrowserEnum expectedBrowserEnum)
+        {
+            // Arrange
+            var testSpecification = new TestSpecification("Fancy scenario", "178wq76essf");           
+            _configurationProvider.UseLocalBrowser.Returns(browser);
+
+            // Act
+            _sut.CreateAndConfigure(testSpecification, "configuration");
+
+            // Assert
+            _browserHostFactory.Received(1).CreateLocalWebDriver(expectedBrowserEnum, null);
+        }
+
+        [Test]
+        public void CreateAndConfigure_ShouldThrowExceptionWhenEnumCannotBeParsed()
+        {
+            // Arrange
+            var testSpecification = new TestSpecification("Fancy scenario", "178wq76essf");
+            _configurationProvider.UseLocalBrowser.Returns("Unsupported");
+
+            Action unsupportedActionBrowser = () => _sut.CreateAndConfigure(testSpecification, null);
+
+            // Act && Assert
+            unsupportedActionBrowser
+                .ShouldThrow<InvalidBrowserConfigurationException>();
         }
     }
 }

--- a/source/TestStack.Seleno.Browserstack.UnitTests/Core/Configuration/RemoteBrowserConfiguratorSpecs.cs
+++ b/source/TestStack.Seleno.Browserstack.UnitTests/Core/Configuration/RemoteBrowserConfiguratorSpecs.cs
@@ -16,6 +16,7 @@ namespace TestStack.Seleno.Browserstack.UnitTests.Core.Configuration
         private IBrowserHostFactory _browserHostFactory;
         private IBrowserConfigurationParser _parser;
         private ICapabilitiesBuilder _capabilitiesBuilder;
+        private IConfigurationProvider _configurationProvider;
 
         [SetUp]
         public void SetUp()
@@ -23,9 +24,10 @@ namespace TestStack.Seleno.Browserstack.UnitTests.Core.Configuration
             _browserHostFactory = Substitute.For<IBrowserHostFactory>();
             _parser = Substitute.For<IBrowserConfigurationParser>();
             _capabilitiesBuilder = Substitute.For<ICapabilitiesBuilder>();
+            _configurationProvider = Substitute.For<IConfigurationProvider>();
 
             _capabilitiesBuilder.WithTestSpecification(Arg.Any<TestSpecification>()).Returns(_capabilitiesBuilder);
-            _sut = new RemoteBrowserConfigurator(_browserHostFactory,_parser, _capabilitiesBuilder);
+            _sut = new RemoteBrowserConfigurator(_browserHostFactory,_parser, _capabilitiesBuilder, _configurationProvider);
         }
 
         [TestCase(null)]

--- a/source/TestStack.Seleno.Browserstack.UnitTests/Core/TestResultNotifierSpecs.cs
+++ b/source/TestStack.Seleno.Browserstack.UnitTests/Core/TestResultNotifierSpecs.cs
@@ -16,6 +16,7 @@ namespace TestStack.Seleno.Browserstack.UnitTests.Core
         private IBrowserStackService _browserStackService;
         private ITraceListener _traceListener;
         private TestResultNotifier _sut;
+        private IConfigurationProvider _configurationProvider;
 
         [SetUp]
         public void SetUp()
@@ -23,7 +24,8 @@ namespace TestStack.Seleno.Browserstack.UnitTests.Core
             _browser = Substitute.For<IBrowserHost>();
             _browserStackService = Substitute.For<IBrowserStackService>();
             _traceListener = Substitute.For<ITraceListener>();
-            _sut = Substitute.ForPartsOf<TestResultNotifier>(_browser, _browserStackService, _traceListener);
+            _configurationProvider = Substitute.For<IConfigurationProvider>();
+            _sut = Substitute.ForPartsOf<TestResultNotifier>(_browser, _browserStackService, _traceListener, _configurationProvider);
         }
 
         [TestCase("")]
@@ -34,7 +36,7 @@ namespace TestStack.Seleno.Browserstack.UnitTests.Core
             // Arrange
             var sessionId = Guid.NewGuid().ToString();
             _browser.SessionId.Returns(emptySessionId);
-
+            
             // Act
             _sut.SendFailingNotificationTestResult();
 
@@ -54,8 +56,7 @@ namespace TestStack.Seleno.Browserstack.UnitTests.Core
             _browser.SessionId.Returns(sessionId);
             _sut.TestException.Returns(null as Exception);
             _browserStackService.GetSessionDetail(sessionId).Returns(new AutomationSession());
-
-
+            
             // Act
             _sut.SendFailingNotificationTestResult();
 
@@ -71,7 +72,7 @@ namespace TestStack.Seleno.Browserstack.UnitTests.Core
             var sessionId = Guid.NewGuid().ToString();
             const string errorMessage = "wrong credentials";
             _browser.SessionId.Returns(sessionId);
-
+            
             _sut.TestException.Returns(new InvalidCredentialException(errorMessage));
             _browserStackService.GetSessionDetail(sessionId).Returns(new AutomationSession());
 
@@ -90,7 +91,7 @@ namespace TestStack.Seleno.Browserstack.UnitTests.Core
             var sessionId = Guid.NewGuid().ToString();
             const string sessionUrl = "http://some/session/url";
             var session = new AutomationSession { BrowserUrl = sessionUrl };
-
+            
             _browser.SessionId.Returns(sessionId);
             _browserStackService.GetSessionDetail(sessionId).Returns(session);
 
@@ -109,7 +110,7 @@ namespace TestStack.Seleno.Browserstack.UnitTests.Core
             var sessionId = Guid.NewGuid().ToString();
             const string videoUrl = "http://some/session/video/url";
             var session = new AutomationSession { VideoUrl = "http://some/session/video/url" };
-
+            
             _browser.SessionId.Returns(sessionId);
             _browserStackService.GetSessionDetail(sessionId).Returns(session);
 

--- a/source/TestStack.Seleno.Browserstack.UnitTests/SpecFlowPlugin/SeleniumNUnitTestGeneratorProviderSpecs.cs
+++ b/source/TestStack.Seleno.Browserstack.UnitTests/SpecFlowPlugin/SeleniumNUnitTestGeneratorProviderSpecs.cs
@@ -83,7 +83,8 @@ namespace TestStack.Seleno.Browserstack.UnitTests.SpecFlowPlugin
             _remoteBrowserConfigurator = new RemoteBrowserConfigurator(new BrowserHostFactory(configurationProvider),
                 new BrowserConfigurationParser(new BrowserStackService(configurationProvider,
                     new HttpClientFactory(configurationProvider))),
-                new CapabilitiesBuilder(configurationProvider));"));
+                new CapabilitiesBuilder(configurationProvider), 
+                configurationProvider);"));
         }
 
         [Test]

--- a/source/TestStack.Seleno.Browserstack.UnitTests/SpecFlowPlugin/SeleniumNUnitTestGeneratorProviderSpecs.cs
+++ b/source/TestStack.Seleno.Browserstack.UnitTests/SpecFlowPlugin/SeleniumNUnitTestGeneratorProviderSpecs.cs
@@ -12,7 +12,6 @@ using TechTalk.SpecFlow.Generator.UnitTestProvider;
 using TechTalk.SpecFlow.Parser;
 using TechTalk.SpecFlow.Utils;
 using TestStack.Seleno.Browserstack.UnitTests.Assertions;
-using TestStack.Seleno.BrowserStack.Core.Extensions;
 using TestStack.Seleno.BrowserStack.SpecFlowPlugin;
 using static System.String;
 


### PR DESCRIPTION
Using the following appconfig setting it's now possible to redirect tests to a local browser instance:

<add key="useLocalBrowser" value="Chrome" />

options are Chrome, Firefox, InternetExplorer, PhantomJs, Safari

See the Seleno local browser setup for more details about ChromeDriver, IEDriverServer etc requirements
